### PR TITLE
More logging and fix for BadNonce transaction rejections

### DIFF
--- a/src/api/v1/controller.ts
+++ b/src/api/v1/controller.ts
@@ -100,7 +100,7 @@ export class Controller {
             tx,
             nonce,
             result,
-          });
+          }, 'failed to broadcast transaction');
           throw new Error(`Broadcast failed: ${result.error} ${result.reason}`);
         } else {
           incrementAccountNonce(account);

--- a/src/api/v1/controller.ts
+++ b/src/api/v1/controller.ts
@@ -88,7 +88,13 @@ export class Controller {
 
         // increment nonce or handle errors
         if ('error' in result) {
-          throw new Error(`Broadcast failed: ${result.error}`);
+          req.logger.warn({
+            tx,
+            network,
+            nonce,
+            result,
+          })
+          throw new Error(`Broadcast failed: ${result.error} ${result.reason}`);
         } else {
           incrementAccountNonce(account);
         }

--- a/src/api/v1/controller.ts
+++ b/src/api/v1/controller.ts
@@ -5,8 +5,10 @@ import {
   broadcastTransaction,
   SponsoredAuthorization,
   StacksTransaction,
+  getAddressFromPrivateKey,
+  TxRejectedReason,
 } from '@stacks/transactions';
-import { bytesToHex } from '@stacks/common';
+import { bytesToHex, TransactionVersion } from '@stacks/common';
 import { StacksMainnet } from '@stacks/network';
 import envVariables from '../../../config/config';
 import { SponsorAccountsKey } from '../../constants';
@@ -15,6 +17,7 @@ import { getAccountAddress } from '../../utils';
 import { validateTransaction } from '../../validation';
 import { Account } from '@stacks/wallet-sdk';
 import cache from '../../cache';
+import { setupAccountNonce } from '../../initialization';
 
 export class Controller {
   info: RequestHandler = async (_, res, next) => {
@@ -82,16 +85,22 @@ export class Controller {
         }
 
         // broadcast transaction
-        const result = await broadcastTransaction(signedTx, network);
+        let result = await broadcastTransaction(signedTx, network);
+
+        if (result?.reason === TxRejectedReason.BadNonce) {
+          req.logger.warn({ tx, nonce, result }, 'Bad nonce. Will update cached nonce and try again');
+          const address = getAddressFromPrivateKey(account.stxPrivateKey, TransactionVersion.Mainnet);
+          await setupAccountNonce(address);
+          result = await broadcastTransaction(signedTx, network);
+        }
 
         // increment nonce or handle errors
         if ('error' in result) {
           req.logger.warn({
             tx,
-            network,
             nonce,
             result,
-          })
+          });
           throw new Error(`Broadcast failed: ${result.error} ${result.reason}`);
         } else {
           incrementAccountNonce(account);


### PR DESCRIPTION
changes:
- add more verbose logging when broadcast transaction fails
- update the cached nonce if transaction is rejected with bad nonce reason, and try broadcast again

issue: 
- https://linear.app/xverseapp/issue/ENG-1444/cant-transfer-an-nft-only-on-mobile

video of local test (with a mocked BadNonce response):

https://github.com/secretkeylabs/stacks-transaction-sponsor/assets/6109710/b27fa499-fe69-4a32-a64a-7428343da727

